### PR TITLE
Restrict access to encyclopedia

### DIFF
--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "../firebase";
+
+export interface UserInfo {
+  email: string;
+  canAccess: boolean;
+  isAdmin: boolean;
+}
+
+export function useUserInfo(uid?: string | null) {
+  const [info, setInfo] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    if (!uid) {
+      setInfo(null);
+      return;
+    }
+    const ref = doc(db, "users", uid);
+    const unsub = onSnapshot(ref, snap => {
+      setInfo(snap.exists() ? (snap.data() as UserInfo) : null);
+    });
+    return () => unsub();
+  }, [uid]);
+
+  return info;
+}

--- a/src/pages/Encyclopedia.tsx
+++ b/src/pages/Encyclopedia.tsx
@@ -3,11 +3,13 @@ import "./Encyclopedia.css";
 import { collection, addDoc, query, orderBy, onSnapshot } from "firebase/firestore";
 import { db } from "../firebase";
 import { useNavigate } from "react-router-dom";
+import { useAuthUser } from "../hooks/useAuth";
+import { useUserInfo } from "../hooks/useUserInfo";
 import search from "../assets/search.svg";
 import plus from "../assets/Plus.svg";
 import left from "../assets/Chevron Left.svg";
 import right from "../assets/Chevron Right.svg";
-import user from "../assets/User.svg";
+import userIcon from "../assets/User.svg";
 
 const INITIAL_TAGS = ["친구", "같은반", "가족", "형", "누나", "지인"];
 const INITIAL_CHO = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"];
@@ -27,7 +29,7 @@ type Person = {
   tags: string[];
   description: string;
   detail?: string;
-  createdAt: any;
+  createdAt: unknown;
 };
 
 const TAG_COLORS: Record<string, string> = {
@@ -43,6 +45,17 @@ const EncyclopediaPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const navigate = useNavigate();
+  const user = useAuthUser();
+  const info = useUserInfo(user?.uid);
+
+  useEffect(() => {
+    if (user === null) {
+      navigate("/login");
+    } else if (info && !info.canAccess) {
+      alert("열람 권한이 없습니다.");
+      navigate("/");
+    }
+  }, [user, info, navigate]);
 
   // Firestore에서 실시간으로 people 가져오기
   useEffect(() => {
@@ -51,7 +64,7 @@ const EncyclopediaPage: React.FC = () => {
       orderBy("name", "asc")
     );
     const unsub = onSnapshot(q, snap => {
-      let arr: Person[] = [];
+      const arr: Person[] = [];
       snap.forEach(docu => {
         const data = docu.data();
         arr.push({ id: docu.id, ...data } as Person);
@@ -60,6 +73,13 @@ const EncyclopediaPage: React.FC = () => {
     });
     return () => unsub();
   }, []);
+
+  if (!user || !info) {
+    return <div className="main-container">불러오는 중...</div>;
+  }
+  if (!info.canAccess) {
+    return null;
+  }
 
   // 초성별 필터 & 검색
   const filtered = people.filter(p => {
@@ -149,7 +169,7 @@ const EncyclopediaPage: React.FC = () => {
                 style={{ cursor: "pointer" }}
               >
                 <div className="avatar">
-                  <img className="user" src={user} alt="user"/>
+                  <img className="user" src={userIcon} alt="user"/>
                 </div>
                 <div className="person-info">
                   <div className="div9">{p.name}</div>

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,7 +1,7 @@
 .login-container {
     width: 100%;
     max-width: 420px;
-    margin: 70px auto;
+    margin: 0 auto;
     padding: 44px 38px 34px 38px;
     background: #fff;
     border-radius: 22px;
@@ -34,9 +34,13 @@
     border-radius: 9px;
     font-size: 1.13rem;
     background: #f7f9fc;
+    color: #23236c;
     outline: none;
     transition: border 0.2s;
     margin-bottom: 4px;
+  }
+  .login-container input::placeholder {
+    color: #94a3b8;
   }
   .login-container input[type="email"]:focus,
   .login-container input[type="password"]:focus {
@@ -78,7 +82,7 @@
     cursor: pointer;
     text-decoration: underline;
   }
-  /* 화면 전체를 flex로 세로+가로 중앙정렬 */
+/* 화면 전체를 flex로 세로+가로 중앙정렬 */
 .main-container.login-bg {
     width: 100vw;
     height: 100vh;
@@ -90,16 +94,5 @@
     box-sizing: border-box;
   }
   
-  .login-container {
-    /* 기존 카드 스타일 유지, max-width, 패딩 등 */
-    max-width: 420px;
-    width: 100%;
-    padding: 44px 38px 34px 38px;
-    background: #fff;
-    border-radius: 22px;
-    box-shadow: 0 8px 32px #23236c19;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+
   

--- a/src/pages/PersonDetailPage.tsx
+++ b/src/pages/PersonDetailPage.tsx
@@ -2,13 +2,34 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { db } from "../firebase";
 import { doc, getDoc } from "firebase/firestore";
-import user from "../assets/User.svg"
+import userIcon from "../assets/User.svg"
 import "./PersonDetailPage.css"
+import { useAuthUser } from "../hooks/useAuth";
+import { useUserInfo } from "../hooks/useUserInfo";
+
+type Person = {
+  name: string;
+  contact?: string;
+  description: string;
+  tags: string[];
+  detail?: string;
+};
 
 const PersonDetailPage: React.FC = () => {
   const { id } = useParams<{id:string}>();
   const navigate = useNavigate();
-  const [person, setPerson] = useState<any>(null);
+  const user = useAuthUser();
+  const info = useUserInfo(user?.uid);
+  const [person, setPerson] = useState<Person | null>(null);
+
+  useEffect(() => {
+    if (user === null) {
+      navigate("/login");
+    } else if (info && !info.canAccess) {
+      alert("열람 권한이 없습니다.");
+      navigate("/");
+    }
+  }, [user, info, navigate]);
 
   useEffect(() => {
     if (!id) return;
@@ -18,14 +39,15 @@ const PersonDetailPage: React.FC = () => {
     });
   }, [id, navigate]);
 
-  if (!person) return <div>불러오는 중...</div>;
+  if (!user || !info || !person) return <div>불러오는 중...</div>;
+  if (!info.canAccess) return null;
 
   return (
     <div className="detail-bg">
     <div className="person-detail-root">
   <div className="person-detail-main">
     <div className="person-detail-avatar">
-      <img src={user} alt="프로필" />
+      <img src={userIcon} alt="프로필" />
     </div>
     <div className="person-detail-info">
       <div className="person-detail-name">{person.name}</div>


### PR DESCRIPTION
## Summary
- gate encyclopedia & detail pages behind login and permission check
- center login popup and make its text readable
- add hook for user info

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68579bc646d883309cd9673feae981da