### PR TITLE
Restrict access to encyclopedia

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,9 +3,9 @@ import { auth } from "../firebase";
 import type { User } from "firebase/auth";
 
 export function useAuthUser() {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<User | null | undefined>(undefined);
   useEffect(() => {
-    const unsub = auth.onAuthStateChanged(setUser);
+    const unsub = auth.onAuthStateChanged(u => setUser(u));
     return () => unsub();
   }, []);
   return user;

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "../firebase";
+
+export interface UserInfo {
+  email: string;
+  canAccess: boolean;
+  isAdmin: boolean;
+}
+
+export function useUserInfo(uid?: string | null) {
+  const [info, setInfo] = useState<UserInfo | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (!uid) {
+      setInfo(null);
+      return;
+    }
+    const ref = doc(db, "users", uid);
+    const unsub = onSnapshot(ref, snap => {
+      setInfo(snap.exists() ? (snap.data() as UserInfo) : null);
+    });
+    return () => unsub();
+  }, [uid]);
+
+  return info;
+}

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -21,8 +21,10 @@ const AdminPanel: React.FC = () => {
 
   // 권한 체크
   useEffect(() => {
-    if (!user) return;
-    if (user.email !== ADMIN_EMAIL) {
+    if (user === undefined) return;
+    if (user === null) {
+      navigate("/login");
+    } else if (user.email !== ADMIN_EMAIL) {
       alert("관리자만 접근 가능합니다.");
       navigate("/");
     }
@@ -30,7 +32,7 @@ const AdminPanel: React.FC = () => {
 
   // 실시간 users 목록 불러오기
   useEffect(() => {
-    if (user?.email !== ADMIN_EMAIL) return;
+    if (!user || user.email !== ADMIN_EMAIL) return;
     const unsubscribe = onSnapshot(collection(db, "users"), snap => {
       const userList: UserInfo[] = [];
       snap.forEach(docu => {

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,7 +1,7 @@
 .login-container {
     width: 100%;
     max-width: 420px;
-    margin: 70px auto;
+    margin: 0 auto;
     padding: 44px 38px 34px 38px;
     background: #fff;
     border-radius: 22px;
@@ -34,9 +34,13 @@
     border-radius: 9px;
     font-size: 1.13rem;
     background: #f7f9fc;
+    color: #23236c;
     outline: none;
     transition: border 0.2s;
     margin-bottom: 4px;
+  }
+  .login-container input::placeholder {
+    color: #94a3b8;
   }
   .login-container input[type="email"]:focus,
   .login-container input[type="password"]:focus {
@@ -78,7 +82,7 @@
     cursor: pointer;
     text-decoration: underline;
   }
-  /* 화면 전체를 flex로 세로+가로 중앙정렬 */
+/* 화면 전체를 flex로 세로+가로 중앙정렬 */
 .main-container.login-bg {
     width: 100vw;
     height: 100vh;
@@ -90,16 +94,5 @@
     box-sizing: border-box;
   }
   
-  .login-container {
-    /* 기존 카드 스타일 유지, max-width, 패딩 등 */
-    max-width: 420px;
-    width: 100%;
-    padding: 44px 38px 34px 38px;
-    background: #fff;
-    border-radius: 22px;
-    box-shadow: 0 8px 32px #23236c19;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+
   

--- a/src/pages/PersonDetailPage.tsx
+++ b/src/pages/PersonDetailPage.tsx
@@ -2,13 +2,35 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { db } from "../firebase";
 import { doc, getDoc } from "firebase/firestore";
-import user from "../assets/User.svg"
+import userIcon from "../assets/User.svg"
 import "./PersonDetailPage.css"
+import { useAuthUser } from "../hooks/useAuth";
+import { useUserInfo } from "../hooks/useUserInfo";
+
+type Person = {
+  name: string;
+  contact?: string;
+  description: string;
+  tags: string[];
+  detail?: string;
+};
 
 const PersonDetailPage: React.FC = () => {
   const { id } = useParams<{id:string}>();
   const navigate = useNavigate();
-  const [person, setPerson] = useState<any>(null);
+  const user = useAuthUser();
+  const info = useUserInfo(user?.uid);
+  const [person, setPerson] = useState<Person | null>(null);
+
+  useEffect(() => {
+    if (user === undefined || info === undefined) return;
+    if (user === null) {
+      navigate("/login");
+    } else if (info && !info.canAccess) {
+      alert("열람 권한이 없습니다.");
+      navigate("/");
+    }
+  }, [user, info, navigate]);
 
   useEffect(() => {
     if (!id) return;
@@ -18,14 +40,17 @@ const PersonDetailPage: React.FC = () => {
     });
   }, [id, navigate]);
 
-  if (!person) return <div>불러오는 중...</div>;
+  if (user === undefined || info === undefined || !person) {
+    return <div>불러오는 중...</div>;
+  }
+  if (user === null || !info?.canAccess) return null;
 
   return (
     <div className="detail-bg">
     <div className="person-detail-root">
   <div className="person-detail-main">
     <div className="person-detail-avatar">
-      <img src={user} alt="프로필" />
+      <img src={userIcon} alt="프로필" />
     </div>
     <div className="person-detail-info">
       <div className="person-detail-name">{person.name}</div>


### PR DESCRIPTION
## Summary
- gate encyclopedia & detail pages behind login and permission check
- center login popup and make its text readable
- add hook for user info
- fix premature redirection by handling auth loading state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68579bc646d883309cd9673feae981da