### PR TITLE
Add admin edit feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "./App.css";
 import AdminPanel from "./pages/AdminPanel";
 
 import PersonDetailPage from "./pages/PersonDetailPage";
+import PersonEditPage from "./pages/PersonEditPage";
 
 const App: React.FC = () => {
   return (
@@ -21,6 +22,7 @@ const App: React.FC = () => {
         <Route path="/admin" element={<AdminPanel />} />
         
         <Route path="/encyclopedia/:id" element={<PersonDetailPage />} />
+        <Route path="/encyclopedia/:id/edit" element={<PersonEditPage />} />
       </Routes>
     </Router>
   );

--- a/src/pages/PersonDetailPage.tsx
+++ b/src/pages/PersonDetailPage.tsx
@@ -70,6 +70,14 @@ const PersonDetailPage: React.FC = () => {
           </div>
         }
         <div className="person-detail-back">
+          {info.isAdmin && (
+            <button
+              onClick={() => navigate(`/encyclopedia/${id}/edit`)}
+              style={{ marginRight: 8 }}
+            >
+              수정
+            </button>
+          )}
           <button onClick={() => navigate(-1)}>목록으로</button>
         </div>
       </div>

--- a/src/pages/PersonEditPage.css
+++ b/src/pages/PersonEditPage.css
@@ -1,0 +1,33 @@
+.edit-container {
+  width: 100%;
+  max-width: 540px;
+  margin: 40px auto;
+  padding: 44px 38px 34px 38px;
+  background: #fff;
+  border-radius: 22px;
+  box-shadow: 0 8px 32px #23236c19;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.edit-container h2 {
+  margin-bottom: 20px;
+  color: #23236c;
+  font-weight: 700;
+  font-size: 2rem;
+}
+
+.edit-container input,
+.edit-container textarea {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ccd;
+  border-radius: 7px;
+  font-size: 16px;
+  box-sizing: border-box;
+}
+
+.edit-container textarea {
+  min-height: 80px;
+}

--- a/src/pages/PersonEditPage.tsx
+++ b/src/pages/PersonEditPage.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { db } from "../firebase";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { useAuthUser } from "../hooks/useAuth";
+import { useUserInfo } from "../hooks/useUserInfo";
+import "./PersonEditPage.css";
+
+const INITIAL_TAGS = ["친구", "같은반", "가족", "형", "누나", "지인"];
+
+type Person = {
+  name: string;
+  contact?: string;
+  description: string;
+  tags: string[];
+  detail?: string;
+};
+
+const PersonEditPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const user = useAuthUser();
+  const info = useUserInfo(user?.uid);
+  const [person, setPerson] = useState<Person | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user === undefined || info === undefined) return;
+    if (user === null) {
+      navigate("/login");
+    } else if (!info?.isAdmin) {
+      alert("관리자만 수정 가능합니다.");
+      navigate(id ? `/encyclopedia/${id}` : "/encyclopedia");
+    }
+  }, [user, info, navigate, id]);
+
+  useEffect(() => {
+    if (!id) return;
+    getDoc(doc(db, "people", id)).then(snap => {
+      if (snap.exists()) setPerson(snap.data() as Person);
+      else navigate("/encyclopedia");
+    });
+  }, [id, navigate]);
+
+  if (user === undefined || info === undefined || person === null) {
+    return <div className="main-container">불러오는 중...</div>;
+  }
+  if (user === null || !info.isAdmin) return null;
+
+  const toggleTag = (tag: string) => {
+    setPerson(cur =>
+      cur
+        ? {
+            ...cur,
+            tags: cur.tags.includes(tag)
+              ? cur.tags.filter(t => t !== tag)
+              : [...cur.tags, tag],
+          }
+        : cur
+    );
+  };
+
+  const save = async () => {
+    if (!person.name.trim()) {
+      setError("이름은 필수입니다!");
+      return;
+    }
+    await updateDoc(doc(db, "people", id!), person);
+    navigate(`/encyclopedia/${id}`);
+  };
+
+  return (
+    <div className="main-container">
+      <div className="edit-container">
+        <h2>문서 수정</h2>
+        <input
+          placeholder="이름"
+          value={person.name}
+          onChange={e => setPerson(p => p && { ...p, name: e.target.value })}
+        />
+        <input
+          placeholder="연락처(선택)"
+          value={person.contact || ""}
+          onChange={e => setPerson(p => p && { ...p, contact: e.target.value })}
+        />
+        <textarea
+          placeholder="간단 설명"
+          value={person.description}
+          onChange={e => setPerson(p => p && { ...p, description: e.target.value })}
+        />
+        <textarea
+          placeholder="세부 설명 (선택)"
+          value={person.detail || ""}
+          onChange={e => setPerson(p => p && { ...p, detail: e.target.value })}
+        />
+        <div style={{ margin: "10px 0 4px 0", fontWeight: 500 }}>태그</div>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          {INITIAL_TAGS.map(tag => (
+            <div
+              key={tag}
+              onClick={() => toggleTag(tag)}
+              style={{
+                background: person.tags.includes(tag) ? "#2563eb" : "#f1f5f9",
+                color: person.tags.includes(tag) ? "#fff" : "#1e293b",
+                borderRadius: 14,
+                padding: "8px 18px",
+                fontSize: 16,
+                cursor: "pointer",
+                border: person.tags.includes(tag)
+                  ? "2px solid #2563eb"
+                  : "1px solid #dbeafe",
+                userSelect: "none",
+              }}
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+        {error && <div style={{ color: "red" }}>{error}</div>}
+        <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+          <button
+            onClick={save}
+            style={{
+              background: "#2563eb",
+              color: "#fff",
+              padding: "11px 32px",
+              border: "none",
+              borderRadius: 7,
+              fontSize: 17,
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            저장
+          </button>
+          <button
+            onClick={() => navigate(-1)}
+            style={{
+              background: "#eee",
+              color: "#23236c",
+              padding: "11px 24px",
+              border: "none",
+              borderRadius: 7,
+              fontSize: 16,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PersonEditPage;


### PR DESCRIPTION
## Summary
- enable admins to edit person data
- show edit button on detail page
- route to an edit page for admins only

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857aa5c5a28833098b02b03e750d6d5