### PR TITLE
Fix lowercase permission field

### DIFF
--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -18,7 +18,21 @@ export function useUserInfo(uid?: string | null) {
     }
     const ref = doc(db, "users", uid);
     const unsub = onSnapshot(ref, snap => {
-      setInfo(snap.exists() ? (snap.data() as UserInfo) : null);
+      if (snap.exists()) {
+        const data = snap.data() as {
+          email?: string;
+          canAccess?: boolean;
+          canaccess?: boolean;
+          isAdmin?: boolean;
+        };
+        setInfo({
+          email: data.email ?? "",
+          canAccess: data.canAccess ?? data.canaccess ?? false,
+          isAdmin: data.isAdmin ?? false,
+        });
+      } else {
+        setInfo(null);
+      }
     });
     return () => unsub();
   }, [uid]);

--- a/src/pages/PersonEditPage.tsx
+++ b/src/pages/PersonEditPage.tsx
@@ -74,7 +74,8 @@ const PersonEditPage: React.FC = () => {
       navigate(`/encyclopedia/${id}`);
     } catch (err) {
       console.error("Firestore 업데이트 실패:", err);
-      setError("수정에 실패했습니다: " + (err as any)?.message);
+      const msg = err instanceof Error ? err.message : String(err);
+      setError("수정에 실패했습니다: " + msg);
     }
   };
 


### PR DESCRIPTION
## Summary
- support `canaccess` field from Firestore in `useUserInfo`
- improve error handling in PersonEditPage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857c155a0cc833096d1c93b60d5388c